### PR TITLE
Add possibility of editor definition to add.vertex.attribute.artifact.editor.count

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 ## Unversioned
 
 ### Added
-- Add a parameter 'editor.definition' to the function 'add.vertex.attribute.artifact.editor.count' which can be used to define, if author or committer or both count as editors when computing the attribute values. (ff1e147ba563b2d71f8228afd49492a315a5ad48)
+- Add a parameter `editor.definition` to the function `add.vertex.attribute.artifact.editor.count` which can be used to define, if author or committer or both count as editors when computing the attribute values. (#92, ff1e147ba563b2d71f8228afd49492a315a5ad48)
 
 
 ## 3.5

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # coronet – Changelog
 
+## Unversioned
+
+### Added
+- Add a parameter 'editor.definition' to the function 'add.vertex.attribute.artifact.editor.count' which can be used to define, if author or committer or both count as editors when computing the attribute values. (ff1e147ba563b2d71f8228afd49492a315a5ad48)
+
 
 ## 3.5
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ While `proximity` triggers a file/function-based commit analysis in `Codeface`, 
 When using this network library, the user only needs to give the `artifact` parameter to the [`ProjectConf`](#projectconf) constructor, which automatically ensures that the correct tagging is selected.
 
 The configuration files `{project-name}_{tagging}.conf` are mandatory and contain some basic configuration regarding a performed `Codeface` analysis (e.g., project name, name of the corresponding repository, name of the mailing list, etc.).
-For further details on those files, please have a look at some [example files](https://github.com/siemens/codeface/tree/master/conf) files in the `Codeface` repository.
+For further details on those files, please have a look at some [example files](https://github.com/siemens/codeface/tree/master/conf) in the `Codeface` repository.
 
 All the `*.list` files listed above are output files of `codeface-extraction` and contain meta data of, e.g., commits or e-mails to the mailing list, etc., in CSV format.
 This network library lazily loads and processes these files when needed.

--- a/tests/test-networks-covariates.R
+++ b/tests/test-networks-covariates.R
@@ -822,7 +822,7 @@ test_that("Test add.vertex.attribute.artifact.editor.count", {
 
     expected.attributes = list(
         range = network.covariates.test.build.expected(
-            c(1L), c(1L), c(3L, 1L)),
+            c(1L), c(2L), c(3L, 1L)),
         cumulative = network.covariates.test.build.expected(
             c(1L), c(2L), c(3L, 1L)),
         all.ranges = network.covariates.test.build.expected(

--- a/tests/test-networks-covariates.R
+++ b/tests/test-networks-covariates.R
@@ -866,7 +866,7 @@ test_that("Test add.vertex.attribute.artifact.editor.count", {
     lapply(AGGREGATION.LEVELS, function(level) {
         networks.with.attr.author = add.vertex.attribute.artifact.editor.count(
             networks.and.data[["networks"]], networks.and.data[["project.data"]],
-            aggregation.level = level, editor.definition = "author"
+            aggregation.level = level
         )
         networks.with.attr.committer = add.vertex.attribute.artifact.editor.count(
             networks.and.data[["networks"]], networks.and.data[["project.data"]],
@@ -874,7 +874,7 @@ test_that("Test add.vertex.attribute.artifact.editor.count", {
         )
         networks.with.attr.both = add.vertex.attribute.artifact.editor.count(
             networks.and.data[["networks"]], networks.and.data[["project.data"]],
-            aggregation.level = level
+            aggregation.level = level, editor.definition = c("author", "committer")
         )
 
         actual.attributes.author = lapply(networks.with.attr.author, igraph::get.vertex.attribute, name = "editor.count")

--- a/tests/test-networks-covariates.R
+++ b/tests/test-networks-covariates.R
@@ -818,9 +818,35 @@ test_that("Test add.vertex.attribute.artifact.editor.count", {
 
     networks.and.data = get.network.covariates.test.networks("artifact")
 
-    expected.attributes = network.covariates.test.build.expected(list(1L), list(1L), list(3L, 1L))
-
-    expected.attributes = list(
+    expected.attributes.author = list(
+        range = network.covariates.test.build.expected(
+            c(1L), c(1L), c(3L, 1L)),
+        cumulative = network.covariates.test.build.expected(
+            c(1L), c(2L), c(3L, 1L)),
+        all.ranges = network.covariates.test.build.expected(
+            c(2L), c(2L), c(3L, 1L)),
+        project.cumulative = network.covariates.test.build.expected(
+            c(1L), c(2L), c(3L, 1L)),
+        project.all.ranges = network.covariates.test.build.expected(
+            c(2L), c(2L), c(3L, 1L)),
+        complete = network.covariates.test.build.expected(
+            c(2L), c(2L), c(3L, 1L))
+    )
+    expected.attributes.committer = list(
+        range = network.covariates.test.build.expected(
+            c(1L), c(1L), c(2L, 1L)),
+        cumulative = network.covariates.test.build.expected(
+            c(1L), c(1L), c(2L, 1L)),
+        all.ranges = network.covariates.test.build.expected(
+            c(1L), c(1L), c(2L, 1L)),
+        project.cumulative = network.covariates.test.build.expected(
+            c(1L), c(1L), c(2L, 1L)),
+        project.all.ranges = network.covariates.test.build.expected(
+            c(1L), c(1L), c(2L, 1L)),
+        complete = network.covariates.test.build.expected(
+            c(1L), c(1L), c(2L, 1L))
+    )
+    expected.attributes.both = list(
         range = network.covariates.test.build.expected(
             c(1L), c(2L), c(3L, 1L)),
         cumulative = network.covariates.test.build.expected(
@@ -838,14 +864,26 @@ test_that("Test add.vertex.attribute.artifact.editor.count", {
     ## Test
 
     lapply(AGGREGATION.LEVELS, function(level) {
-        networks.with.attr = add.vertex.attribute.artifact.editor.count(
+        networks.with.attr.author = add.vertex.attribute.artifact.editor.count(
+            networks.and.data[["networks"]], networks.and.data[["project.data"]],
+            aggregation.level = level, editor.definition = "author"
+        )
+        networks.with.attr.committer = add.vertex.attribute.artifact.editor.count(
+            networks.and.data[["networks"]], networks.and.data[["project.data"]],
+            aggregation.level = level, editor.definition = "committer"
+        )
+        networks.with.attr.both = add.vertex.attribute.artifact.editor.count(
             networks.and.data[["networks"]], networks.and.data[["project.data"]],
             aggregation.level = level
         )
 
-        actual.attributes = lapply(networks.with.attr, igraph::get.vertex.attribute, name = "editor.count")
+        actual.attributes.author = lapply(networks.with.attr.author, igraph::get.vertex.attribute, name = "editor.count")
+        actual.attributes.committer = lapply(networks.with.attr.committer, igraph::get.vertex.attribute, name = "editor.count")
+        actual.attributes.both = lapply(networks.with.attr.both, igraph::get.vertex.attribute, name = "editor.count")
 
-        expect_equal(expected.attributes[[level]], actual.attributes)
+        expect_equal(expected.attributes.author[[level]], actual.attributes.author)
+        expect_equal(expected.attributes.committer[[level]], actual.attributes.committer)
+        expect_equal(expected.attributes.both[[level]], actual.attributes.both)
     })
 })
 

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -666,7 +666,8 @@ add.vertex.attribute.author.role = function(list.of.networks, classification.res
 #'                          \code{"project.cumulative"}, \code{"project.all.ranges"}, and
 #'                          \code{"complete"}. See \code{split.data.by.networks} for
 #'                          more details. [default: "range"]
-#' @param editor.definition Determines, who is counted as editor of an artifact. [default: c("author", "committer")]
+#' @param editor.definition Determines, who is counted as editor of an artifact (one ore more of
+#'                          \code{c("author", "committer")}). [default: "author"]
 #' @param default.value The default value to add if a vertex has no matching value [default: 0]
 #'
 #' @return A list of networks with the added attribute
@@ -679,15 +680,19 @@ add.vertex.attribute.artifact.editor.count = function(list.of.networks, project.
     aggregation.level = match.arg.or.default(aggregation.level, default = "range")
 
     ## match editor definitions to column name in commit dataframe
-    editor.definition = match.arg.or.default(editor.definition, several.ok = TRUE)
-    editor.definition = lapply(editor.definition, function(editor) {paste0(editor, ".name")})
+    if (missing(editor.definition)) {
+        editor.definition = "author"
+    } else {
+        editor.definition = match.arg.or.default(editor.definition, choices = c("author", "committer"), several.ok = TRUE)
+    }
+    editor.definition = paste0(editor.definition, ".name")
 
     nets.with.attr = split.and.add.vertex.attribute(
         list.of.networks, project.data, name, aggregation.level, default.value,
         function(range, range.data, net) {
             vertex.attributes = lapply(range.data$group.authors.by.data.column("commits", "artifact"),
                    function(artifact.commits) {
-                       editor.count = length(unique(unlist(lapply(editor.definition, function(editor.type) {artifact.commits[[editor.type]]}))))
+                       editor.count = length(unique(unlist(artifact.commits[editor.definition])))
                        return(editor.count)
                    }
             )

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -666,6 +666,7 @@ add.vertex.attribute.author.role = function(list.of.networks, classification.res
 #'                          \code{"project.cumulative"}, \code{"project.all.ranges"}, and
 #'                          \code{"complete"}. See \code{split.data.by.networks} for
 #'                          more details. [default: "range"]
+#' @param editor.definition Determines, who is counted as editor of an artifact. [default: c("author", "committer")]
 #' @param default.value The default value to add if a vertex has no matching value [default: 0]
 #'
 #' @return A list of networks with the added attribute
@@ -673,15 +674,20 @@ add.vertex.attribute.artifact.editor.count = function(list.of.networks, project.
                                                       aggregation.level = c("range", "cumulative", "all.ranges",
                                                                             "project.cumulative", "project.all.ranges",
                                                                             "complete"),
+                                                      editor.definition = c("author", "committer"),
                                                       default.value = 0) {
     aggregation.level = match.arg.or.default(aggregation.level, default = "range")
+
+    ## match editor definitions to column name in commit dataframe
+    editor.definition = match.arg.or.default(editor.definition, several.ok = TRUE)
+    editor.definition = lapply(editor.definition, function(editor) {paste0(editor, ".name")})
 
     nets.with.attr = split.and.add.vertex.attribute(
         list.of.networks, project.data, name, aggregation.level, default.value,
         function(range, range.data, net) {
             vertex.attributes = lapply(range.data$group.authors.by.data.column("commits", "artifact"),
-                   function(x) {
-                       editor.count = length(unique(c(x[["author.name"]], x[["committer.name"]])))
+                   function(artifact.commits) {
+                       editor.count = length(unique(unlist(lapply(editor.definition, function(editor.type) {artifact.commits[[editor.type]]}))))
                        return(editor.count)
                    }
             )

--- a/util-networks-covariates.R
+++ b/util-networks-covariates.R
@@ -679,11 +679,13 @@ add.vertex.attribute.artifact.editor.count = function(list.of.networks, project.
     nets.with.attr = split.and.add.vertex.attribute(
         list.of.networks, project.data, name, aggregation.level, default.value,
         function(range, range.data, net) {
-            lapply(range.data$group.authors.by.data.column("commits", "artifact"),
+            vertex.attributes = lapply(range.data$group.authors.by.data.column("commits", "artifact"),
                    function(x) {
-                       length(unique(x[["author.name"]]))
+                       editor.count = length(unique(c(x[["author.name"]], x[["committer.name"]])))
+                       return(editor.count)
                    }
             )
+            return(vertex.attributes)
         }
     )
 


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](https://github.com/se-passau/coronet/blob/master/CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](https://github.com/se-passau/coronet/blob/master/NEWS.md) appropriately.
- [x] The pull request is opened against the branch `dev`.

### Description

Add a parameter 'editor.definition' to the function 'add.vertex.attribute.artifact.editor.count' which can be used to define, if author or committer or both count as editors when computing the attribute values.

### Changelog

Add a parameter 'editor.definition' to the function 'add.vertex.attribute.artifact.editor.count' which can be used to define, if author or committer or both count as editors when computing the attribute values. (ff1e147ba563b2d71f8228afd49492a315a5ad48)
