### PR TITLE
Add patchstack mail filtering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 
 ### Added
 - Add a parameter `editor.definition` to the function `add.vertex.attribute.artifact.editor.count` which can be used to define, if author or committer or both count as editors when computing the attribute values. (#92, ff1e147ba563b2d71f8228afd49492a315a5ad48)
+- Add the possibility to filter out patchstack mails from the mails of the `ProjectData`. The option can be toggled using the newly added configuration option `mails.filter.patchstack.mails`. (1608e28ca36610c58d2a5447d12ee2052c6eb976, a932c8cdaa6fe5149c798bc09d9e421ba679c48d)
 
 
 ## 3.5

--- a/README.md
+++ b/README.md
@@ -521,6 +521,10 @@ There is no way to update the entries, except for the revision-based parameters.
 - `commits.filter.untracked.files`
     * Remove all information concerning untracked files from the commit data. This effect becomes clear when retrieving commits using `get.commits.filtered`, because then the result of which does not contain any commits that solely changed untracked files. Networks built on top of this `ProjectData` do also not contain any information about untracked files.
     * [*`TRUE`*, `FALSE`]
+- `mails.filter.patchstack.mails`
+    * Filter patchstack mails from the mail data. In a thread, a patchstack spans the first sequence of mails where each mail has been authored by the thread creator and has been sent within a short time window after the preceding mail. The mails spanned by a patchstack are called
+'patchstack mails' and for each patchstack, every patchstack mail but the first one are filtered when `mails.filter.patchstack.mails = TRUE`.
+    * [`TRUE`, *`FALSE`*]
 - `issues.only.comments`
     * Only use comments from the issue data on disk and no further events such as references and label changes
     * [*`TRUE`*, `FALSE`]

--- a/tests/test-data.R
+++ b/tests/test-data.R
@@ -12,7 +12,8 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2018 by Christian Hechtl <hechtl@fim.uni-passau.de>
-## Copyright 2018 by Claus Hunsen <hunsen@fim.uni-passau.de>
+## Copyright 2018-2019 by Claus Hunsen <hunsen@fim.uni-passau.de>
+## Copyright 2019 by Jakob Kronawitter <kronawij@fim.uni-passau.de>
 ## All Rights Reserved.
 
 

--- a/tests/test-data.R
+++ b/tests/test-data.R
@@ -172,8 +172,8 @@ test_that("Filter patchstack mails with PaStA enabled", {
     expect_true("<jlkjsdgihwkfjnvbjwkrbnwe@mail.gmail.com>" %in% filtered.pasta[["message.id"]])
     expect_equal(2, sum(filtered.pasta[["message.id"]] == "<saf54sd4gfasf46asf46@mail.gmail.com>"))
 
-    ## ensure that out of three PaStA entries that existed previously, all of which pointing to the same commit hash,
-    ## one new PaStA entry has been created with has assigned the message ID of the first patchstack mail
+    ## ensure that the three PaStA entries relating to the filtered patchstack mails have been merged to a single new
+    ## PaStA entry which has assigned the message ID of the first patchstack mail
     expect_true("<hans1@mail.gmail.com>" %in% filtered.pasta[["message.id"]])
 
     ## ensure that there are no other entries than the ones that have been verified to exist above

--- a/tests/test-data.R
+++ b/tests/test-data.R
@@ -34,6 +34,7 @@ test_that("Compare two ProjectData objects", {
 
     ##initialize a ProjectData object with the ProjectConf and clone it into another one
     proj.conf = ProjectConf$new(CF.DATA, CF.SELECTION.PROCESS, CASESTUDY, ARTIFACT)
+    proj.conf$update.value("pasta", TRUE)
     proj.data.one = ProjectData$new(project.conf = proj.conf)
     proj.data.two = proj.data.one$clone()
 
@@ -43,19 +44,20 @@ test_that("Compare two ProjectData objects", {
     ## second object, as well, and test for equality.
 
     ##change the second data object
-    proj.data.one$get.commits()
-
-    expect_false(proj.data.one$equals(proj.data.two), "Two not identical ProjectData objects.")
-
-    proj.data.two$get.commits()
-
-    expect_true(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects.")
 
     proj.data.two$get.pasta()
 
     expect_false(proj.data.one$equals(proj.data.two), "Two not identical ProjectData objects.")
 
     proj.data.one$get.pasta()
+
+    expect_true(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects.")
+
+    proj.data.one$get.commits()
+
+    expect_false(proj.data.one$equals(proj.data.two), "Two not identical ProjectData objects.")
+
+    proj.data.two$get.commits()
 
     expect_true(proj.data.one$equals(proj.data.two), "Two identical ProjectData objects.")
 

--- a/tests/test-data.R
+++ b/tests/test-data.R
@@ -166,12 +166,16 @@ test_that("Filter patchstack mails with PaStA enabled", {
     ## retrieve filtered PaStA data by calling 'get.pasta' which calls the filtering functionality internally
     filtered.pasta = proj.data$get.pasta()
 
-    ## ensure that PaStA data relating to Hans' mail 2 and 3 do not exist anymore since they have also been filtered
-    ## during patchstack mail filtering
-    expect_false("<hans2@mail.gmail.com>" %in% filtered.pasta[["message.id"]])
-    expect_false("<hans3@mail.gmail.com>" %in% filtered.pasta[["message.id"]])
+    ## ensure that the remaining mails have not been touched
+    expect_true("<adgkljsdfhkwafdkbhjasfcjn@mail.gmail.com>" %in% filtered.pasta[["message.id"]])
+    expect_true("<asddghdswqeasdasd@mail.gmail.com>" %in% filtered.pasta[["message.id"]])
+    expect_true("<jlkjsdgihwkfjnvbjwkrbnwe@mail.gmail.com>" %in% filtered.pasta[["message.id"]])
+    expect_equal(2, sum(filtered.pasta[["message.id"]] == "<saf54sd4gfasf46asf46@mail.gmail.com>"))
 
-    ## ensure that all three PaStA entries that existed previously do still exist but have been associated to the
-    ## very first mail of the patchstack
-    expect_equal(3, sum(filtered.pasta[["message.id"]] == "<hans1@mail.gmail.com>"))
+    ## ensure that out of three PaStA entries that existed previously, all of which pointing to the same commit hash,
+    ## one new PaStA entry has been created with has assigned the message ID of the first patchstack mail
+    expect_true("<hans1@mail.gmail.com>" %in% filtered.pasta[["message.id"]])
+
+    ## ensure that there are no other entries than the ones that have been verified to exist above
+    expect_equal(6, nrow(filtered.pasta))
 })

--- a/util-conf.R
+++ b/util-conf.R
@@ -355,6 +355,12 @@ ProjectConf = R6::R6Class("ProjectConf", inherit = Conf,
                 allowed = c(TRUE, FALSE),
                 allowed.number = 1
             ),
+            mails.filter.patchstack.mails = list(
+                default = FALSE,
+                type = "logical",
+                allowed = c(TRUE, FALSE),
+                allowed.number = 1
+            ),
             synchronicity = list(
                 default = FALSE,
                 type = "logical",

--- a/util-data.R
+++ b/util-data.R
@@ -63,6 +63,9 @@ DATASOURCE.TO.ARTIFACT.COLUMN = list(
     "issues"  = "issue.id"
 )
 
+## the maximum time difference between subsequent mails of a patchstack
+PATCHSTACK.MAIL.DECAY.THRESHOLD = "30 seconds"
+
 
 ## / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
 ## ProjectData -------------------------------------------------------------
@@ -101,6 +104,7 @@ ProjectData = R6::R6Class("ProjectData",
         commits = NULL, # data.frame
         ## mails
         mails = NULL, # data.frame
+        mails.patchstacks = NULL, # list
         ## issues
         issues = NULL, #data.frame
         ## authors
@@ -113,36 +117,137 @@ ProjectData = R6::R6Class("ProjectData",
         ## timestamps of mail, issue and commit data
         data.timestamps = NULL, #data.frame
 
-        ## * * filtering commits -------------------------------------------
+        ## * * commit filtering --------------------------------------------
 
-        #' Filter commits retrieved by the method \code{get.commits} after potentially removing untracked files and the
-        #' base artifact (see parameters).
+        #' Filter commits by potentially removing untracked files and the base artifact (see parameters).
         #'
+        #' @param commits the data.frame of commits to be filtered
         #' @param remove.untracked.files flag whether untracked files are kept or removed
         #' @param remove.base.artifact flag whether the base artifact is kept or removed
         #'
-        #' @return the commits retrieved by the method \code{get.commits} after all filters have been applied
-        filter.commits = function(remove.untracked.files, remove.base.artifact) {
+        #' @return the commits after all filters have been applied
+        filter.commits = function(commits, remove.untracked.files, remove.base.artifact) {
             logging::logdebug("filter.commits: starting.")
-
-            ## get commit data
-            commit.data = self$get.commits()
 
             ## filter out the untracked files
             if (remove.untracked.files) {
-                commit.data = subset(commit.data, file != UNTRACKED.FILE)
+                commits = subset(commits, file != UNTRACKED.FILE)
             }
 
             ## filter out the base artifacts (i.e., Base_Feature, File_Level)
             if (remove.base.artifact) {
-                commit.data = subset(commit.data, !(artifact %in% BASE.ARTIFACTS))
+                commits = subset(commits, !(artifact %in% BASE.ARTIFACTS))
             }
 
             logging::logdebug("filter.commits: finished.")
-            return(commit.data)
+            return(commits)
+        },
+
+        ## * * mail filtering ----------------------------------------------
+
+        #' Filters patchstack mails from the mails that are currently cached in the field \code{mails} and returns them.
+        #' Detected patchstacks are also stored in the field \code{patchstack.mails}. They are used later in the
+        #' function \code{filter.pasta.data} to also accommodate for the deleted mails in the PaStA data.
+        #'
+        #' In a thread, a patchstack spans the first sequence of mails where each mail has been authored by the thread
+        #' creator and has been sent within a short time window (see \code{PATCHSTACK.MAIL.DECAY.THRESHOLD}) after the
+        #' preceding mail.
+        #' The mails spanned by a patchstack are called 'patchstack mails'.
+        #'
+        #' For each patchstack, all patchstack mails but the first one are filtered.
+        #'
+        #' @return the mail data after filtering patchstack mails
+        filter.patchstack.mails = function() {
+            logging::logdebug("filter.patchstack.mails: starting.")
+
+            ## retrieve mails grouped by thread IDs
+            thread.data = self$group.authors.by.data.column("mails", "thread")
+
+            result = parallel::mclapply(thread.data, function(thread) {
+
+                ## ensure that all mails within the thread are ordered correctly
+                thread = thread[order(thread["date"]), ]
+
+                running = TRUE
+                i = 1
+
+                ## find the largest index 'i' for which holds that each mail up to index 'i' has been authored by the
+                ## thread creator and that all mails up to index 'i' have been received within a succesive time window
+                ## of 'PATCHSTACK.MAIL.DECAY.THRESHOLD'
+                while (i < nrow(thread) && running) {
+                    if (thread[1, "author.name"] == thread[i + 1, "author.name"] &&
+                        thread[i + 1, "date"] - thread[i, "date"] <=
+                        lubridate::as.duration(PATCHSTACK.MAIL.DECAY.THRESHOLD)) {
+                        i = i + 1
+                    } else {
+                        running = FALSE
+                    }
+                }
+
+                ## return the mails of the thread with all patchstack mails but the first one being removed
+                return (list(keep = thread[setdiff(seq_len(nrow(thread)), seq_len(i)[-1]), ],
+                             patchstack = thread[seq_len(i), ]))
+            })
+
+            ## override thread data with filtered thread data
+            thread.data = lapply(result, function(x) x[["keep"]])
+
+            ## flatten the list of mail-dataframes (i.e. thread.data) to a single mail-dataframe
+            mails = plyr::rbind.fill(thread.data)
+
+            ## Retrieve patchstacks from the result above which are used to manipulate the PaStA data. This needs to be
+            ## done because the PaSta data relates to some of the filtered mails and must be adjusted accordingly.
+            patchstacks = lapply(result, function(x) x[["patchstack"]])
+
+            ## only patchstacks that contain at least two mails are considered patchstacks
+            patchstacks = patchstacks[lapply(patchstacks, nrow) > 1]
+
+            ## store patchstack information
+            private$mails.patchstacks = patchstacks
+
+            logging::logdebug("filter.patchstack.mails: finished.")
+            return(mails)
         },
 
         ## * * PaStA data --------------------------------------------------
+
+        #' Uses the information about the deleted patchstack mails that are stored in the field \code{patchstack.mails}
+        #' to also filter out PaStA information that relates to the deleted mails. The PaStA information is not
+        #' discarded completely however but instead is gathered for each patchstack and is assigned to the first mail
+        #' in each patchstack because this very first mail has not been filtered and represents the patchstack.
+        #'
+        #' @return the filtered PaStA data
+        filter.pasta.data = function() {
+            logging::logdebug("filter.pasta.data: starting.")
+
+            new.pasta = parallel::mclapply(private$mails.patchstacks, function(patchstack) {
+
+                ## get all PaStA data that relates to the current mail (do not drop data.frame structure!)
+                pasta.tmp = private$pasta[private$pasta[["message.id"]] %in% patchstack[["message.id"]], , drop = FALSE]
+
+                ## override all old message IDs with the message ID of the first mail in the patchstack since it
+                ## is the only one that is kept (if any data is available in 'pasta.tmp')
+                if (nrow(pasta.tmp) > 0) {
+                    pasta.tmp["message.id"] = patchstack[1, "message.id"]
+                }
+
+                return(pasta.tmp)
+            })
+            ## combine new re-written PaStA data
+            new.pasta = plyr::rbind.fill(new.pasta)
+
+            ## remove old items from PaStA data
+            ## 1) flatten the list of mail-dataframes (i.e. patchstacks) to a single mail-dataframe
+            patchstack.mails = plyr::rbind.fill(private$mails.patchstacks)
+            ## 2) delete any PaStA information that relate to message IDs of mails that will be discarded
+            pasta = private$pasta[!(private$pasta[["message.id"]] %in% patchstack.mails[["message.id"]]), ]
+
+            ## append the new pasta to the old pasta
+            pasta = plyr::rbind.fill(pasta, new.pasta)
+
+            logging::logdebug("filter.pasta.data: finished.")
+            return(pasta)
+        },
 
         #' Aggregate PaStA data for convenient merging to main data sources.
         #'
@@ -153,17 +258,14 @@ ProjectData = R6::R6Class("ProjectData",
         #'
         #' **Note**: The column \code{commit.hash} gets renamed to \code{hash} to match
         #' the corresponding column in the commit data (see \code{read.commits}).
-        #'
-        #' @param pasta.data a data.frame of PaStA data as retrieved from
-        #'                   \code{ProjectData$get.pasta.data}
-        aggregate.pasta.data = function(pasta.data) {
+        aggregate.pasta.data = function() {
             logging::logdebug("aggregate.pasta.data: starting.")
 
             ## check for data first
-            if (nrow(pasta.data) == 0) {
+            if (nrow(private$pasta) == 0) {
                 ## take (empty) input data and no rows from it
-                private$pasta.mails = pasta.data[0, ]
-                private$pasta.commits = pasta.data[0, ]
+                private$pasta.mails = create.empty.pasta.list()
+                private$pasta.commits = create.empty.pasta.list()
             } else {
                 ## compute aggregated data.frames for easier merging
                 ## 1) define group function (determines result in aggregated data.frame cells)
@@ -171,13 +273,13 @@ ProjectData = R6::R6Class("ProjectData",
                 ## 2) aggregate by message ID
                 group.col = "message.id"
                 private$pasta.mails = aggregate(
-                    as.formula(sprintf(". ~ %s", group.col)), pasta.data,
+                    as.formula(sprintf(". ~ %s", group.col)), private$pasta,
                     group.fun, na.action = na.pass
                 )
                 ## 3) aggregate by commit hash
                 group.col = "commit.hash"
                 private$pasta.commits = aggregate(
-                    as.formula(sprintf(". ~ %s", group.col)), pasta.data,
+                    as.formula(sprintf(". ~ %s", group.col)), private$pasta,
                     group.fun, na.action = na.pass
                 )
             }
@@ -187,6 +289,98 @@ ProjectData = R6::R6Class("ProjectData",
             colnames(private$pasta.commits) = c("hash", "pasta", "revision.set.id")
 
             logging::logdebug("aggregate.pasta.data: finished.")
+        },
+
+        #' Updates the PaStA column that is appended to mails using the currently available PaStA data from the field
+        #' \code{pasta.commits}.
+        update.pasta.commit.data = function() {
+            logging::logdebug("update.pasta.commit.data: starting.")
+
+            ## return immediately if no commits available
+            if (!is.null(private$mails)) {
+
+                ## remove previous PaStA data
+                private$commits["pasta"] = NULL
+                private$commits["revision.set.id"] = NULL
+
+                ## merge PaStA data
+                private$commits = merge(private$commits, private$pasta.commits,
+                                    by = "hash", all.x = TRUE, sort = FALSE)
+            }
+
+            logging::logdebug("update.pasta.commit.data: finished.")
+        },
+
+        #' Updates the PaStA column that is appended to mails using the currently available PaStA data from the field
+        #' \code{pasta.mails}.
+        update.pasta.mail.data = function() {
+            logging::logdebug("update.pasta.mail.data: starting.")
+
+            ## return immediately if no mails available
+            if (!is.null(private$mails)) {
+
+                ## remove previous PaStA data
+                private$mails["pasta"] = NULL
+                private$mails["revision.set.id"] = NULL
+
+                ## merge PaStA data
+                private$mails = merge(private$mails, private$pasta.mails,
+                                      by = "message.id", all.x = TRUE, sort = FALSE)
+            }
+
+            logging::logdebug("update.pasta.mail.data: finished.")
+        },
+
+        #' Recomputes the values of the cached fields \code{pasta.mails} and \code{pasta.commits} using the currrently
+        #' available PaStA information of the field \code{pasta} and also assigns/updates this PaStA information to
+        #' \code{mails} and \code{commits}.
+        #'
+        #' This method should be called whenever the field \code{pasta} is changed.
+        update.pasta.data = function() {
+            logging::logdebug("update.pasta.data: starting.")
+
+            ## filter patchstack mails from PaStA data if configured
+            if (private$project.conf$get.value("mails.filter.patchstack.mails")) {
+                private$pasta = private$filter.pasta.data()
+            }
+
+            ## aggregate by message IDs and commit hashes
+            private$aggregate.pasta.data()
+
+            ## update mail data by attaching PaStA data
+            if (!is.null(private$mails)) {
+                private$update.pasta.mail.data()
+            }
+
+            ## update commit data by attaching PaStA data
+            if (!is.null(private$commits)) {
+                private$update.pasta.commit.data()
+            }
+
+            logging::logdebug("update.pasta.data: finished.")
+        },
+
+        ## * * synchronicity data ------------------------------------------
+
+        #' Updates the synchronicity column that is appended to commits using the currently available synchronicity data
+        #' from the field \code{synchronicity}.
+        #'
+        #' This method should be called whenever the field \code{synchronicity} is changed.
+        update.synchronicity.data = function() {
+            logging::logdebug("update.synchronicity.data: starting.")
+
+            ## update commit data by attaching synchronicity data
+            if (!is.null(private$commits)) {
+                ## remove previous synchronicity data
+                private$commits["synchronicity"] = NULL
+
+                ## merge synchronicity data
+                private$commits = merge(private$commits, private$synchronicity,
+                                    by = "hash", all.x = TRUE, sort = FALSE)
+
+            }
+
+            logging::logdebug("update.synchronicity.data: finished.")
         },
 
         ## * * timestamps --------------------------------------------------
@@ -388,6 +582,7 @@ ProjectData = R6::R6Class("ProjectData",
         get.commits.filtered = function() {
             if (is.null(private$commits.filtered)) {
                 private$commits.filtered = private$filter.commits(
+                    self$get.commits(),
                     private$project.conf$get.value("commits.filter.untracked.files"),
                     private$project.conf$get.value("commits.filter.base.artifact")
                 )
@@ -408,7 +603,7 @@ ProjectData = R6::R6Class("ProjectData",
         #'
         #' @seealso get.commits.filtered
         get.commits.filtered.uncached = function(remove.untracked.files, remove.base.artifact) {
-            return (private$filter.commits(remove.untracked.files, remove.base.artifact))
+            return (private$filter.commits(self$get.commits(), remove.untracked.files, remove.base.artifact))
         },
 
         #' Get the list of commits which have the artifact kind configured in the \code{project.conf}.
@@ -445,43 +640,37 @@ ProjectData = R6::R6Class("ProjectData",
         set.commits = function(commit.data) {
             logging::loginfo("Setting commit data.")
 
-            # TODO: Also check for correct shape (column names and data types) of the passed data
-
             if (is.null(commit.data)) {
                 commit.data = create.empty.commits.list()
             }
 
-            ## append synchronicity data if wanted
+            ## temporarily store commit data to enable attachment of PaStA stuff
+            private$commits = commit.data
+
+            ## add synchronicity data if wanted
             if (private$project.conf$get.value("synchronicity")) {
-                logging::loginfo("Adding synchronicity data.")
-                synchronicity.data = self$get.synchronicity()
-                ## remove previous synchronicity data
-                if ("synchronicity" %in% colnames(commit.data)) {
-                    commit.data["synchronicity"] = NULL
+                if (is.null(private$synchronicity)) {
+                    ## get data (no assignment because we just want to trigger anything synchronicity-related)
+                    self$get.synchronicity()
+                } else {
+                    ## update all synchronicity-related data
+                    private$update.synchronicity.data()
                 }
-                commit.data = merge(commit.data, synchronicity.data,
-                                    by = "hash", all.x = TRUE, sort = FALSE)
             }
 
             ## add PaStA data if wanted
             if (private$project.conf$get.value("pasta")) {
-                logging::loginfo("Adding PaStA data.")
-                ## get data
-                self$get.pasta() # no assignment because we just want to trigger the read-in
-                ## remove previous PaStA data
-                if ("pasta" %in% colnames(commit.data)) {
-                    commit.data["pasta"] = NULL
-                    commit.data["revision.set.id"] = NULL
+                if (is.null(private$pasta)) {
+                    ## get data (no assignment because we just want to trigger anything PaStA-related)
+                    self$get.pasta()
+                } else {
+                    ## update all PaStA-related data
+                    private$update.pasta.data()
                 }
-                ## merge PaStA data
-                commit.data = merge(commit.data, private$pasta.commits,
-                                    by = "hash", all.x = TRUE, sort = FALSE)
             }
 
             ## sort by date again (because 'merge' is doing bullshit!)
             commit.data = commit.data[order(commit.data[["date"]], decreasing = FALSE), ] # sort!
-
-            private$commits = commit.data
 
             ## remove cached data for filtered commits as these need to be re-computed after
             ## changing the data
@@ -500,16 +689,19 @@ ProjectData = R6::R6Class("ProjectData",
             if (private$project.conf$get.value("synchronicity")) {
                 ##  if data are not read already, read them
                 if (is.null(private$synchronicity)) {
-                    synchronicity.data = read.synchronicity(
+                    private$synchronicity = read.synchronicity(
                         self$get.data.path.synchronicity(),
                         private$project.conf$get.value("artifact"),
                         private$project.conf$get.value("synchronicity.time.window")
                     )
 
-                    ## set actual data
-                    self$set.synchronicity(synchronicity.data)
+                    ## no read of commit data needed here!
+
+                    ## update all synchronicity-related data
+                    private$update.synchronicity.data()
                 }
             } else {
+                logging::logwarn("You have not set the ProjectConf parameter 'synchronicity' to 'TRUE'! Ignoring...")
                 ## mark synchronicity data as empty
                 self$set.synchronicity(NULL)
             }
@@ -534,10 +726,11 @@ ProjectData = R6::R6Class("ProjectData",
 
             ## add synchronicity data to the commit data if configured
             if (private$project.conf$get.value("synchronicity")) {
-                logging::loginfo("Updating synchronicity data.")
-                if (!is.null(private$commits)) {
-                    self$set.commits(private$commits)
-                }
+
+                ## no read of commit data needed here!
+
+                ## update all synchronicity-related data
+                private$update.synchronicity.data()
             }
         },
 
@@ -553,12 +746,21 @@ ProjectData = R6::R6Class("ProjectData",
             if (private$project.conf$get.value("pasta")) {
                 ## if data are not read already, read them
                 if (is.null(private$pasta)) {
-                    pasta.data = read.pasta(self$get.data.path.pasta())
+                    ## read PaStA data from disk
+                    private$pasta = read.pasta(self$get.data.path.pasta())
 
-                    ## set actual data
-                    self$set.pasta(pasta.data)
+                    ## read mail data if filtering patchstack mails
+                    if (is.null(private$mails)
+                        && private$project.conf$get.value("mails.filter.patchstack.mails")) {
+                        ## just triggering read-in, no storage
+                        self$get.mails()
+                    } else {
+                        ## update all PaStA-related data
+                        private$update.pasta.data()
+                    }
                 }
             } else {
+                logging::logwarn("You have not set the ProjectConf parameter 'pasta' to 'TRUE'! Ignoring...")
                 ## mark PaStA data as empty
                 self$set.pasta(NULL)
             }
@@ -581,17 +783,19 @@ ProjectData = R6::R6Class("ProjectData",
             ## set the actual data
             private$pasta = data
 
-            ## aggregate by message IDs and commit hashes
-            private$aggregate.pasta.data(private$pasta)
-
             ## add PaStA data to commit and mail data if configured
             if (private$project.conf$get.value("pasta")) {
-                logging::loginfo("Updating PaStA data.")
-                if (!is.null(private$commits)) {
-                    self$set.commits(private$commits)
-                }
-                if (!is.null(private$mails)) {
-                    self$set.mails(private$mails)
+
+                ## read mail data if filtering patchstack mails
+                if (is.null(private$mails) &&
+                    private$project.conf$get.value("mails.filter.patchstack.mails")) {
+                    ## just triggering read-in, no storage
+                    self$get.mails()
+
+                } else {
+                    ## update all PaStA-related data
+                    private$update.pasta.data()
+
                 }
             }
         },
@@ -609,7 +813,7 @@ ProjectData = R6::R6Class("ProjectData",
             if (is.null(private$mails)) {
                 mails.read = read.mails(self$get.data.path())
 
-                self$set.mails(data = mails.read)
+                self$set.mails(mails.read)
             }
             private$extract.timestamps(source = "mails")
 
@@ -619,33 +823,35 @@ ProjectData = R6::R6Class("ProjectData",
         #' Set the mail data to the given new data and add PaStA data
         #' if configured in the field \code{project.conf}.
         #'
-        #' @param data the new mail data
-        set.mails = function(data) {
+        #' @param mail.data the new mail data
+        set.mails = function(mail.data) {
             logging::loginfo("Setting e-mail data.")
 
-            if (is.null(data)) {
-                data = create.empty.mails.list()
+            if (is.null(mail.data)) {
+                mail.data = create.empty.mails.list()
+            }
+
+            ## temporarily store mail data to enable attachment of PaStA stuff
+            private$mails = mail.data
+
+            ## filter patchstack mails and store again
+            if (private$project.conf$get.value("mails.filter.patchstack.mails")) {
+                private$mails = private$filter.patchstack.mails()
             }
 
             ## add PaStA data if wanted
             if (private$project.conf$get.value("pasta")) {
-                logging::loginfo("Adding PaStA data.")
-                ## get data
-                self$get.pasta() # no assignment because we just want to trigger the read-in
-                ## remove previous PaStA data
-                if ("pasta" %in% colnames(data)) {
-                    data["pasta"] = NULL
-                    data["revision.set.id"] = NULL
+                if (is.null(private$pasta)) {
+                    ## get data (no assignment because we just want to trigger anything PaStA-related)
+                    self$get.pasta()
+                } else {
+                    ## update all PaStA-related data
+                    private$update.pasta.data()
                 }
-                ## merge PaStA data
-                data = merge(data, private$pasta.mails,
-                             by = "message.id", all.x = TRUE, sort = FALSE)
             }
 
             ## sort by date again (because 'merge' is doing bullshit!)
-            data = data[order(data[["date"]], decreasing = FALSE), ] # sort!
-
-            private$mails = data
+            private$mails = private$mails[order(private$mails[["date"]], decreasing = FALSE), ] # sort!
         },
 
         #' Get the author data.

--- a/util-data.R
+++ b/util-data.R
@@ -239,6 +239,9 @@ ProjectData = R6::R6Class("ProjectData",
             ## combine new re-written PaStA data
             new.pasta = plyr::rbind.fill(new.pasta)
 
+            ## remove potential duplicates
+            new.pasta = unique(new.pasta)
+
             ## remove old items from PaStA data
             ## 1) flatten the list of mail-dataframes (i.e. patchstacks) to a single mail-dataframe
             patchstack.mails = plyr::rbind.fill(private$mails.patchstacks)
@@ -247,6 +250,9 @@ ProjectData = R6::R6Class("ProjectData",
 
             ## append the new pasta data to the old pasta data
             pasta = plyr::rbind.fill(pasta, new.pasta)
+
+            ## reestablish ordering using the 'revision.set.id' column of the PaStA data
+            pasta = pasta[order(pasta[["revision.set.id"]]), ]
 
             logging::logdebug("filter.pasta.data: finished.")
             return(pasta)
@@ -309,6 +315,9 @@ ProjectData = R6::R6Class("ProjectData",
                 ## merge PaStA data
                 private$commits = merge(private$commits, private$pasta.commits,
                                     by = "hash", all.x = TRUE, sort = FALSE)
+
+                ## sort by date again because 'merge' disturbs the order
+                private$commits = private$commits[order(private$commits[["date"]], decreasing = FALSE), ]
             }
 
             logging::logdebug("update.pasta.commit.data: finished.")
@@ -329,6 +338,9 @@ ProjectData = R6::R6Class("ProjectData",
                 ## merge PaStA data
                 private$mails = merge(private$mails, private$pasta.mails,
                                       by = "message.id", all.x = TRUE, sort = FALSE)
+
+                ## sort by date again because 'merge' disturbs the order
+                private$mails = private$mails[order(private$mails[["date"]], decreasing = FALSE), ]
             }
 
             logging::logdebug("update.pasta.mail.data: finished.")
@@ -380,6 +392,9 @@ ProjectData = R6::R6Class("ProjectData",
                 ## merge synchronicity data
                 private$commits = merge(private$commits, private$synchronicity,
                                     by = "hash", all.x = TRUE, sort = FALSE)
+
+                ## sort by date again because 'merge' disturbs the order
+                private$commits = private$commits[order(private$commits[["date"]], decreasing = FALSE), ]
 
             }
 
@@ -672,8 +687,8 @@ ProjectData = R6::R6Class("ProjectData",
                 }
             }
 
-            ## sort by date again (because 'merge' is doing bullshit!)
-            commit.data = commit.data[order(commit.data[["date"]], decreasing = FALSE), ] # sort!
+            ## sort by date
+            private$commits = private$commits[order(private$commits[["date"]], decreasing = FALSE), ]
 
             ## remove cached data for filtered commits as these need to be re-computed after
             ## changing the data
@@ -851,8 +866,8 @@ ProjectData = R6::R6Class("ProjectData",
                 }
             }
 
-            ## sort by date again (because 'merge' is doing bullshit!)
-            private$mails = private$mails[order(private$mails[["date"]], decreasing = FALSE), ] # sort!
+            ## sort by date
+            private$mails = private$mails[order(private$mails[["date"]], decreasing = FALSE), ]
         },
 
         #' Get the author data.


### PR DESCRIPTION
<!-- Put an X between the brackets in any line below if you have done the task. -->
- [X] I adhere to the coding conventions (described [here](https://github.com/se-passau/coronet/blob/master/CONTRIBUTING.md)) in my code.
- [X] I have updated the copyright headers of the files I have modified.
- [X] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [X] I have put signed-off tags in *all* commits.
- [X] I have updated the changelog file [NEWS.md](https://github.com/se-passau/coronet/blob/master/NEWS.md) appropriately.
- [X] The pull request is opened against the branch `dev`.

### Description

This pull request enables patchstack mails to be filtered from the mails of the ProjectData.

### Changelog

Add the possibility to filter out patchstack mails from the mails of the ProjectData. The option can be toggled using
the newly added configuration option 'mails.filter.patchstack.mails'. (1608e28ca36610c58d2a5447d12ee2052c6eb976, c44c82b525e557a6cfe1f498478d2a7815ee9ae8)