### PR TITLE
Travis fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@
 ## 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
 ##
 ## Copyright 2017-2018,2020 by Claus Hunsen <hunsen@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## All Rights Reserved.
 
 # TravisCI container
@@ -26,6 +27,7 @@ r:
   - 3.4
   - 3.5
   - 3.6
+  - 4.0
 cache: packages
 repos:
   CRAN: https://cloud.r-project.org

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,6 +9,8 @@
 
 ### Changed/Improved
 - Adjust the function `get.authors.by.data.source`: Rename its single parameter to `data.sources` and change the function so that it can extract the authors for multiple data sources at once. The default value of the parameter is a vector containing all the available data sources (commits, mails, issues) (051a5f0287022f97e2367ed0e9591b9df9dbdb3d)
+- Adjust recommended R version to 3.6.3 in README (92be262514277acb774ab2885c1c0d1c10f03373)
+- Add R version 4.0 to test suite and adjust package installation in `install.R` to improve compatibility with Travis CI (40aa0d80e2a94434a8be75925dbefbde6d3518b2, 1ba036758a63767e2fcef525c98f5a4fd6938c39, #161)
 
 
 ## 3.6

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If you wonder: The name `coronet` derives as an acronym from the words "configur
 
 - [Integration](#integration)
     * [Requirements](#requirements)
-        * [R](#r-331)
+        * [R](#r)
         * [packrat (recommended)](#packrat)
         * [Folder structure of the input data](#folder-structure-of-the-input-data)
         * [Needed R packages](#needed-r-packages)
@@ -53,9 +53,11 @@ If you wonder: The name `coronet` derives as an acronym from the words "configur
 
 While using the package, we require the following infrastructure.
 
-#### [`R`](https://www.r-project.org/) `3.3.1`
+#### [`R`](https://www.r-project.org/) 
 
-Later `R` versions should work (and are tested using our TravisCI script), but, for reliability reasons and `packrat` compatibility, only version `3.3.1` is supported.
+Minimum requirement is `R` version `3.3.1`. Hence, later `R` versions also work.
+
+We currently recommend version `3.6.3` for reliability reasons and `packrat` compatibility, but also later versions (`>=4`) should work (and are tested using our TravisCI script).
 
 #### [`packrat`](http://rstudio.github.io/packrat/) (recommended)
 

--- a/install.R
+++ b/install.R
@@ -16,6 +16,7 @@
 ## Copyright 2015 by Wolfgang Mauerer <wolfgang.mauerer@oth-regensburg.de>
 ## Copyright 2015-2017 by Claus Hunsen <hunsen@fim.uni-passau.de>
 ## Copyright 2017 by Thomas Bock <bockthom@fim.uni-passau.de>
+## Copyright 2020 by Thomas Bock <bockthom@cs.uni-saarland.de>
 ## Copyright 2019 by Anselm Fehnker <fehnker@fim.uni-passau.de>
 ## All Rights Reserved.
 ##
@@ -55,5 +56,7 @@ filter.installed.packages = function(packageList)  {
 p = filter.installed.packages(packages)
 if (length(p) > 0) {
     print(sprintf("Installing package '%s'.", p))
-    install.packages(p, dependencies = TRUE, verbose = FALSE, quiet = FALSE)
+
+    ## set dependencies to 'NA' to install only necessary dependencies (i.e., "Depends", "Imports", "LinkingTo")
+    install.packages(p, dependencies = NA, verbose = TRUE, quiet = TRUE)
 }


### PR DESCRIPTION
<!--
Thanks for contributing to coronet!
-->
### Prerequisites

<!-- Put an X between the brackets in any line below if you have done the task. -->
- [x] I adhere to the coding conventions (described [here](https://github.com/se-passau/coronet/blob/master/CONTRIBUTING.md)) in my code.
- [x] I have updated the copyright headers of the files I have modified.
- [x] I have written appropriate commit messages, i.e., I have recorded the goal, the need, the needed changes, and the location of my code modifications for each commit. This includes also, e.g., referencing to relevant issues.
- [x] I have put signed-off tags in *all* commits.
- [x] I have updated the changelog file [NEWS.md](https://github.com/se-passau/coronet/blob/master/NEWS.md) appropriately.
- [x] The pull request is opened against the branch `dev`.

### Description

Adjust package installation script to fix Travis CI builds:
    
    Travis builds currently fail (for a few weeks) due to two different reasons:
    
    On the one hand, the log output exceeds the maximum log length of travis,
    resulting in failing builds. This is prevented by setting the parameters
    `verbose` and `quiet` to `TRUE`, as then the package compilation log is
    not printed to the log but the result of package installation is clearly
    perceptible in the log.
    
    On the other hand, travis installs lots of packages which are not necessary
    as they are just suggestions of other packages but not necessary dependencies.
    Installing such unnecessary packages my lead to problems. This is
    circumvented by setting the `dependencies` parameter to `NA` as this results
    in installing only necessary dependencies and imports, whereas the former
    `TRUE` value of this parameter also led to installing suggested but
    unnecessary packages.
    
    Those two fixes make the Travis CI builds successful again.
    
    Props to @clhunsen for experimenting with the parameters and proposing
    the first part of this commit regarding the `verbose` and `quiet`
    parameters of the `install.packages` function.

    In addition, add R version 4.0 to the test suite.



### Changelog
- Adjust package installation in `install.R` to improve compatibility with Travis CI (1ba036758a63767e2fcef525c98f5a4fd6938c39, #161)
- Adjust recommended R version to 3.6.3 in README (92be262514277acb774ab2885c1c0d1c10f03373)
- Add R version 4.0 to test suite (40aa0d80e2a94434a8be75925dbefbde6d3518b2, #161)

